### PR TITLE
Traducción de archivos Readme

### DIFF
--- a/README_es.md
+++ b/README_es.md
@@ -1,0 +1,50 @@
+# asw2122_0
+
+[![Actions Status](https://github.com/pglez82/asw2122_0/workflows/CI%20for%20ASW2122/badge.svg)](https://github.com/pglez82/asw2122_0/actions)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=pglez82_asw2122_0&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=pglez82_asw2122_0)
+[![codecov](https://codecov.io/gh/pglez82/asw2122_0/branch/master/graph/badge.svg?token=VN4XG9NTRO)](https://codecov.io/gh/pglez82/asw2122_0)
+
+<p float="left">
+<img src="https://blog.wildix.com/wp-content/uploads/2020/06/react-logo.jpg" height="100">
+<img src="https://miro.medium.com/max/1200/0*RbmfNyhuBb8G3LWh.png" height="100">
+<img src="https://miro.medium.com/max/365/1*Jr3NFSKTfQWRUyjblBSKeg.png" height="100">
+</p>
+
+Este proyecto es un ejemplo basico de un sitio web utilizando **React** con **Typescript** y un endpoint usando **NodeJS** con **express**
+
+## Guia de inicio rápido
+
+<mark>Si tienes instalados node.js y npm, asegurate de actualizarlos antes de intentar construir las imagenes</mark>
+
+Si quieres ejecutar el proyecto necesitarás [git](https://git-scm.com/downloads), [Node.js and npm](https://www.npmjs.com/get-npm) y [Docker](https://docs.docker.com/get-docker/). Asegurate de tenerlos instalados en tu equipo. Descarga el proyecto con `git clone https://github.com/pglez82/asw2122_0`. La manera más rápìda de ejecutar todo es con Docker.
+
+```bash
+docker-compose up --build
+```
+Este comando creará dos imagenes de docker si no existen en tu equipo (la webapp y la restapi) y lanzará un contenedor de mongoDB. Además lanzará contenedores de Prometheus y Grafana para monitorizar el servicio web. Deberias ser capaz de acceder a todo desde aqui:
+
+ - [Webapp - http://localhost:3000](http://localhost:3000)
+ - [Ejemplo llamada a RestApi - http://localhost:5000/api/users/list](http://localhost:5000/api/users/list)
+ - [Metricas RestApi - http://localhost:5000/metrics](http://localhost:5000/metrics)
+ - [Servidor Prometheus - http://localhost:9090](http://localhost:9090)
+ - [Servidor Grafana http://localhost:9091](http://localhost:9091)
+ 
+Si quieres ejecutar el proyecto sin Docker primero complila y ejecuta la aplicación web:
+```shell
+cd webapp
+npm install
+npm start
+```
+a continuación la restapi:
+```shell
+cd restapi
+npm install
+npm start
+```
+Deberias ser capaz de acceder a la aplicación en [http://localhost:3000](http://localhost:3000).
+
+## Mas información
+Encontrarás más información sobre el repositorio en los otros archivos README:
+- Documentación: https://github.com/pglez82/asw2122_0/tree/master/docs
+- Webapp: https://github.com/pglez82/asw2122_0/tree/master/webapp
+- Restapi: https://github.com/pglez82/asw2122_0/tree/master/restapi

--- a/docs/README_es.md
+++ b/docs/README_es.md
@@ -1,0 +1,25 @@
+## Documentación
+La documentación de este proyecto se compila localmente y se despliega en GitHub pages.
+la url en la que se despliega es: [https://pglez82.github.io/asw2122_0/](https://pglez82.github.io/asw2122_0/).
+
+### Build Documentación
+For the documentation we are going to use [AsciiDoc](https://asciidoc.org/) and [PlantUML](https://plantuml.com) and follows the [Arc42](https://github.com/arc42/arc42-template) template. If you want to be able to generate the doc locally you need to install Ruby and some dependencies to translate the asciidoc code into html:
+
+Para la documentación vamos a utilizar [AsciiDoc](https://asciidoc.org/) y [PlantUML](https://plantuml.com). Seguiremos la plantilla [Arc42](https://github.com/arc42/arc42-template). Si quieres generar la documentación de forma local necesitas instalar Ruby y algunas dependencias para traducir el código de AsciiDoc a html.
+
+```shell
+cd docs
+apt-get install ruby openjdk-8-jre
+gem install asciidoctor asciidoctor-diagram
+npm install
+```
+Una vez instaladas estas herramientas podremos generar la documentación
+```shell
+npm run build
+```
+La documentación se generará en el directorio `docs/build`.
+
+### Despliegue Documentación
+Si queremos desplegar la documentación en GitHub pages, estará accesible en [https://pglez82.github.io/asw2122_0/](https://pglez82.github.io/asw2122_0/) necesitamos ejecutar `npm run deploy`.
+
+Si revisas el `package.json` de este directorio veras como desplegar es tan facil como ejecutar `gh-pages -d build`, que puede hacerse ejecutando directamente `npm run deploy` en el directorio de la doumentación. el paquete `gh-pages` se encarga de subir la documentación generada (basicamente archivo html) a una rama especial de github llamda gh-pages. Todo lo que se suba a esa rama es acesible en la página del repositorio. Ten en cuenta que solo queremos subir ahí la documentación. También es importante que el build de la documentación no se suba a otras ramas del proyecto.

--- a/restapi/README_es.md
+++ b/restapi/README_es.md
@@ -1,0 +1,51 @@
+## Restapi
+
+El objetivo de esta parte es crear una al rest APi utilizando Express y Node.js con TypeScript. Solo vamos a implementar dos funciones. Una petición post para registrar un nuevo usuario y una petición get que devolverá un listado de todos los usuarios en el sistema. Es servicio web se desplegará utilizando Docker.
+
+Vamos a analizar los paquetes principales utilizados en esta parte (archivo package.json):
+- express: Es la dependencia principal para la construcción de la API. Express es un framework web de NodeJS muy util para la construcción de endpoints de una API aunque permite otras funcionalidades
+- cors: Cross-Origin Resource Sharing, Es util para permitir peticiones solo desde determinados dominios, en este ejemplo,unicamente permitimos peticiones desde el localhost.
+- express-validator: Util para la validación de las peticiones de la API. Mejora la seguridad evitando ataques de inyección de código.    
+- express-prom-bundle y prom-client: Middleware para capturar las peticiones y enviar estadísticas a prometheus. Es muy util para monitorizar nuestro servicio web.
+- @types packages. Tipos para programar utilizando Typescript.
+     
+Este código es bastante sencillo, el archivo [server.ts](server.ts) lanza la API y en el archivo [api.ts](api.ts) donde ESTÁN las 2 peticiones. 
+
+Para lanzar la API podemos ejecutar `npm start`. Este comando lanzará el archivo `server.ts`. El paquete `ts-node-dev` recargará el servidor cada vez que guardemos algún cambio en nuestro código de Typescript. Es muy útil.
+
+### Testeando la rest api
+Para testear necesitamos simular peticiones contra la API. Para hacer esto utilizaremos una herramienta llamada [Supertest](https://www.npmjs.com/package/supertest).
+
+<mark>Ojo: Estas dependencias se guardaran para modo desarrollo, no son necesarias en producción.</mark>
+
+La idea es utilizar Jest (como en la webapp) como framework principal de testing. Para realizar las peticiones GET o POST utilizaremos Supertest. El archivo [api.test.ts](tests/api.test.ts), contiene la implementación de los tests. El método `beforeAll` se carga al iniciar la API.
+
+Tras configurar los tests en el `package.json` podemos ejecutarlos utilizando `npm run test`.
+
+### Imagen Docker para la restapi
+En el Dockerfile de este directorio se encuentran los comandos para construir una imagen de la restapi. Solo tenemos que instalar las dependencias y arrancar la API utilizando `npm start`.
+
+### Monitorización (Prometheus y Grafana)
+En esta etapa vamos a utilizar [Prometheus](https://prometheus.io/) y [Grafana](https://grafana.com/) para monitorizar nuestra restapi. El primer paso es modificar el lanzamiento de la restapi para capturar los datos de "profiling". En Nodejs es muy sencillo, tras instalar los paquetes necesarios (express-prom-bundle y prom-client), debemos modificar el `restapi/server.js` para capturar los datos de profiling añadiendo:
+```javascript
+const metricsMiddleware = promBundle({includeMethod: true});
+app.use(metricsMiddleware);
+```
+Ahora cuando lancemos la API en [http://localhost:5000/metrics](http://localhost:5000/metrics) tendremos un endpoint de metricas con datos de desempeño. La idea es tener otra pieza de software corriendo (llamada [Prometheus](https://prometheus.io/)) que cogerá estos datos, digamos, cada cinco segundos. a continuación otro software llamado [Grafana](https://grafana.com/) los mostrará con graficos chulos.
+
+Para lanzar Prometheus y Grafana podemos utilizar diferentes imagenes de Docker. Comprueba `docker-compose.yml` para ver como se lanzan estas imagenes. 
+
+<mark>Ojo: en `prometheus.yml` le estamos indicando a prometheus donde esta el endpoint de metricas de nuesta restapi. En Grafana `datasources/datasource.yml` indicamos donde encontrar los datos de prometheus.</mark>
+
+<mark>En ambos archivos de configuración necesitamos establecer las uris de las metricas de la resapi y de la fuente de datos de prometheus. En este momento están configurados para utilizar la red de docker-compose.  Si quieres utilizar estos comandos de docker individualmente tienes que cambiar las uris para que apunten al localhost</mark>
+
+Una vez lanzado esto todo el sistema está corriendo (ver la guia de inicio rápido). Ahora podemos simular unas cuantas peticiones en nuestro servicio web.
+
+```
+sudo apt-get install apache2-utils
+ab -m GET -n 10000 -c 100 http://localhost:5000/api/users/list
+```
+
+En el cuadro de mando de Grafana podemos ver como aumenta rapidamente el número de peticiones tras llamarla.
+
+Una buena referencia con explicaciones sobre monitorización en Nodejs puede encontrarse [Aqui](https://github.com/coder-society/nodejs-application-monitoring-with-prometheus-and-grafana).

--- a/webapp/README_es.md
+++ b/webapp/README_es.md
@@ -1,0 +1,93 @@
+## La webapp
+Utilizaremos React con Typescript para la webapp. Vamos a crear la app en el directorio webapp con los siguientes comandos (asegurate que npm está instalado en tu sistema:)
+```console
+npx create-react-app my-app --template typescript
+```
+En este punto ya podemos correr la app con:
+```console
+cd webapp
+npm start
+```
+La app se lanzará y escuchará en el puerto 3000. Ahora mismo la app es un "Hola Mundo" en React.
+Vamos a hacer algunas modificaciones en la app, crearemos una app que pida el nombre y el email al usuario y lo envíe a una api rest.Además la webapp listará todos los usuarios registrados.
+
+Basicamente la app debería ser capaz de coger el nombre y el email del usuario, enviarlo a la api y refrescar la lista de los usuarios desde la api. Puedes revisar el código relevante en los componentes
+[EmailForm.tsx](src/components/EmailForm.tsx) y [UserList.tsx](src/components/UserList.tsx). El componente [App.tsx](src/App.tsx) funciona como coordinador de los otros componentes.
+
+### Testeando la webapp
+
+#### Tests unitarios
+Basicamente estos tests se aseguran que cada componente trabaja de manera aislada. Esto es importante para comprobar que se renderizan correctamente. Estos tests se realizan utilizando jest y pueden ejercutarse con `npm run test`. Cada vez que se ejecutan los tests se realiza un analisis de covertura de código. Si se configura apropiadamente este analisis puede ser explotado por herramientas como [CodeCov](https://about.codecov.io/) para crear informes de covertura de código.
+
+Algunos tests necesitan simular algunas partes de la aplicación. Por ejemplo el componente `EmailForm.tsx` utiliza la api para añadir un usuario. En los tests unitarios debemos simular estas llamadas para obtener resultados más robustos. Puedes revisar el archivo [EmailForm.test.tsx](src/components/EmailForm.test.tsx) para aprender como se hace esto.
+Por ejemplo:
+```javascript
+jest.spyOn(api,'addUser').mockImplementation((user:User):Promise<boolean> => Promise.resolve(false))
+```
+Simularemos la función addUser. En lugar de llamar a la API, simulamos que el servicio web ha fallado al tratar de añadir un usuario.
+
+### Imagen Docker para la aplicación web
+El `Dockerfile` para la aplicación web es bastante simple. Solo copia la aplicación, instala las dependencias, crea la versión de producción y corre un servidor web básico para lanzarla.
+
+Necesitamos un servidor para poder correr la aplicación. No es recomendable ejecutar `npm start` en un entorno de producción por lo que utilizaremos [Express](https://expressjs.com/es/). Revisa [server.js](webapp/server.ts) en el directotio webapp para entender la configuración. Mientras corramos el servicio en el puerto 3000 (en localhost) tendremos que conectar este puerto con el puerto de nuestra máquina local.
+
+### Lanzar todo al mismo tiempo (docker-compose)
+doker compose permite lanzar todos los contenedores en el orden adecuado. Revisa el archivo [docker-compose.yaml](docker-compose.yaml) para ver la definición de los contenedores y sus procesos de lanzamiento. Aqui tienes los comandos para lanzar el sistema y apagarlo:
+```
+docker-compose up
+```
+```
+docker-compose down
+```
+<mark>Nota: Si cambias algo en el código deberás reconstruir las imagenes utilizando la bandera `--build`.</mark>
+
+### Continuous integration/Continuous Delivery
+In this step we are going to setup GitHub Actions in order to have CI in our system. The idea is that, every time we create a new release, build the system (restapi and webapp), run the tests, and if everything is ok, build the docker images and upload them to Github packages. Then we can deploy the application using these images.
+
+The workflow for this is in [asw2122.yml](.github/workflow/asw2122.yml). In this file you can see that there are two jobs, one for the restapi, one for the webapp. Jobs are executed in pararel so this will speed up our build.
+
+So, the first to jobs in this file build the webapp and the restapi (in parallel). If everything goes well, check the e2e tests (later in this document) and if these acceptance tests pass ok, create the docker images and deploy them.
+
+
+### E2E testing
+Integration tests is maybe the most difficult part to integrate in our system. We have to test the system as a whole. The idea here is to deploy the system and make the tests using [jest-puppeteer](https://github.com/smooth-code/jest-puppeteer) (browser automatization) and [jest-cucumber](https://www.npmjs.com/package/jest-cucumber) (user stories). We will also be using [expect-puppeteer](https://www.npmjs.com/package/expect-puppeteer) to make easier the test writing. All the structure needed is under the `webapp/e2e` directory. This tests can be run locally using `npm run test:e2e` and they will be run also in GitHub Actions, just after the unitary tests. 
+
+In this project the E2E testing user stories are defined using Cucumber. Cucumber uses a language called Gherkin to define the user stories. You can find the example in the `features` directory. Then, the actual tests are in the folder `steps`. We are going to configure jest to execute only the tests of this directory (check the `jest.config.ts` file). 
+
+The E2E tests have two extra difficulties. The first one, we need a browser to perform the tests as if the user was using the application. For this matter, we use `jest-peppeteer` that will launch a Chromium instance for running the tests. The browser is started in the `beforeAll` function. Note that the browser is launched in a headless mode. This is neccesary for the tests to run in the CI environment. If you want to debug the tests you can always turn this feature off. The second problem is that we need to run the restapi and the webapp at the same time to be able to run the tests. For achieving this, we are going to use the package `start-server-and-test`. This package, allows us to launch multiple servers and then run the tests. No need for any configuration. We can configure it straight in the `package.json` file:
+
+```json
+"test:e2e": "start-server-and-test 'npm --prefix ../restapi start' http://localhost:5000/api/users/list prod 3000 'cd e2e && jest'"
+```
+
+The package accepts pairs of parameters (launch a server and an URL to check if it is running. It also accepts npm commands (for instance prod, for the webapp, that will run `npm run prod`). The last parameter of the task will be launching jest to run the E2E tests.
+
+### Load testing (Gatling)
+This part will be carried out using [Gatling](https://gatling.io/). Gatling will simulate load in our system making petitions to the webapp.
+
+In order to use Gatling for doing the load tests in our application we need to [download](https://gatling.io/open-source/start-testing/) it. Basically, the program has two parts, a [recorder](https://gatling.io/docs/current/http/recorder) to capture the actions that we want to test and a program to run this actions and get the results. Gatling will take care of capture all the response times in our requests and presenting them in quite useful graphics for its posterior analysis.
+
+Once we have downloaded Gatling we need to start the [recorder](https://gatling.io/docs/current/http/recorder). This works as a proxy that intercepts all the actions that we make in our browser. That means that we have to configure our browser to use a proxy. We have to follow this steps:
+
+1. Configure the recorder in **HTTP proxy mode**.
+2. Configure the **HTTPs mode** to Certificate Authority.
+3. Generate a **CA certificate** and key. For this, press the Generate CA button. You will have to choose a folder to generate the certificates. Two pem files will be generated.
+4. Configure Firefox to use this **CA certificate** (Preferences>Certificates, import the generated certificate).
+5. Configure Firefox to use a **proxy** (Preferences>Network configuration). The proxy will be localhost:8000.
+6. Configure Firefox so it uses this proxy even if the call is to a local address. In order to do this, we need to set the property `network.proxy.allow_hijacking_localhost` to `true` in `about:config`. 
+
+Once we have the recorder configured, and the application running (in Heroku for instance), we can start recording our first test. We must specify a package and class name. This is just for test organization. Package will be a folder and Class name the name of the test. In my case I have used `GetUsersList` without package name. After pressing start the recorder will start capturing our actions in the browser. So here you should perform all the the actions that you want to record. In my case I just browsed to the Heroku deployed webapp. Once we stop recording the simulation will be stored under the `user-files/simulations` directory, written in [Scala](https://www.scala-lang.org/) language. I have copied the generated file under `webapp/loadtestexample` just in case you want to see how a test file in gatling looks like.
+
+Podemos modificar nuestro test de carga ,por ejemplo, inyectando 20 usuarios al mismo tiempo:
+```
+setUp(scn.inject(atOnceUsers(20))).protocols(httpProtocol)
+```
+changing it in the scala file.
+In order to execute the test we have to execute:
+```
+gatling.sh -s GetUsersExample
+```
+
+In the console, we will get an overview of the results and in the results directory we will have the full report in web format.
+
+It is important to note that we could also dockerize this load tests using this [image](https://hub.docker.com/r/denvazh/gatling). It is just a matter of telling the docker file where your gatling configuration and scala files are and the image will do the rest.


### PR DESCRIPTION
He traducido los archivos readme a español. En cada directorio he creado un archivo `README_es.md` con la traducción.

- Creo que en la webapp falta el archivo `webapp/loadtestexample` donde se muestra un ejemplo de un test creado con Gatling.

- También se habla del despliegue en Heroku. Cuando sepamos dónde lo desplegamos hay q actualizar ese par de lineas para que la doc esté impecable.

Unos readme muy chulos Pablo! Me quito el sombrero por el trabajo.

Creo que todos los alumnos deberían leerlos porque se coge perspectiva de que se hace en cada caso.